### PR TITLE
    minor hotfixes to standard keywords and returns for catalog evaluations

### DIFF
--- a/csep/__init__.py
+++ b/csep/__init__.py
@@ -173,6 +173,7 @@ def load_catalog(filename, type='csep-csv', format='native', loader=None, apply_
 
     if apply_filters:
         return_val = return_val.filter().filter_spatial()
+
     return return_val
 
 

--- a/csep/core/catalog_evaluations.py
+++ b/csep/core/catalog_evaluations.py
@@ -39,7 +39,7 @@ def number_test(forecast, observed_catalog):
                                      name='Catalog N-Test',
                                      observed_statistic=obs_count,
                                      quantile=(delta_1, delta_2),
-                                     status='Normal',
+                                     status='normal',
                                      obs_catalog_repr=str(observed_catalog),
                                      sim_name=forecast.name,
                                      min_mw=forecast.min_magnitude,
@@ -135,7 +135,18 @@ def magnitude_test(forecast, observed_catalog):
     # short-circuit if zero events
     if observed_catalog.event_count == 0:
         print("Cannot perform magnitude test when observed event count is zero.")
-        return None
+        # prepare result
+        result = CatalogMagnitudeTestResult(test_distribution=test_distribution,
+                                            name='M-Test',
+                                            observed_statistic=None,
+                                            quantile=(None, None),
+                                            status='not-valid',
+                                            min_mw=forecast.min_magnitude,
+                                            obs_catalog_repr=str(observed_catalog),
+                                            obs_name=observed_catalog.name,
+                                            sim_name=forecast.name)
+
+        return result
 
     # compute expected rates for forecast if needed
     if forecast.expected_rates is None:
@@ -174,7 +185,7 @@ def magnitude_test(forecast, observed_catalog):
                               name='M-Test',
                               observed_statistic=obs_d_statistic,
                               quantile=(delta_1, delta_2),
-                              status='Normal',
+                              status='normal',
                               min_mw=forecast.min_magnitude,
                               obs_catalog_repr=str(observed_catalog),
                               obs_name=observed_catalog.name,
@@ -279,6 +290,7 @@ def calibration_test(evaluation_results, delta_1=False):
             delta_1 (bool): use delta_1 for quantiles. default false -> use delta_2 quantile score for calibration test
     """
 
+    # this is using "delta_2" which is the cdf value less-equal
     idx = 0 if delta_1 else 1
     quantiles = [result.quantile[idx] for result in evaluation_results]
     ks, p_value = scipy.stats.kstest(quantiles, 'uniform')

--- a/csep/core/forecasts.py
+++ b/csep/core/forecasts.py
@@ -262,7 +262,7 @@ class GriddedForecast(MarkedGriddedDataSet):
         res = self.scale(fore_frac)
         return res
 
-    def target_event_rates(self, target_catalog, scale=True):
+    def target_event_rates(self, target_catalog, scale=False):
         """ Generates data set of target event rates given a target data.
 
         The data should already be scaled to the same length as the forecast time horizon. Explicit checks for these

--- a/csep/core/poisson_evaluations.py
+++ b/csep/core/poisson_evaluations.py
@@ -503,10 +503,13 @@ def _poisson_likelihood_test(forecast_data, observed_data, num_simulations=1000,
     if use_observed_counts:
         scale = n_obs / n_fore
         expected_forecast_count = int(n_obs)
-        log_bin_expectations = numpy.log(forecast_data.ravel() * scale)
+        # Numpy warnings can occur if forecasts have masked cells and thus zero valued rates
+        with numpy.errstate(divide='ignore'):
+            log_bin_expectations = numpy.log(forecast_data.ravel() * scale)
     else:
         expected_forecast_count = numpy.sum(forecast_data)
-        log_bin_expectations = numpy.log(forecast_data.ravel())
+        with numpy.errstate(divide='ignore'):
+            log_bin_expectations = numpy.log(forecast_data.ravel())
 
     # gets the 1d indices to bins that contain target events, these indexes perform copies and not views into the array
     target_idx = numpy.nonzero(observed_data.ravel())

--- a/csep/utils/plots.py
+++ b/csep/utils/plots.py
@@ -1228,6 +1228,9 @@ def plot_calibration_test(evaluation_result, axes=None, plot_args=None, show=Fal
     xlabel = plot_args.get('xlabel', 'Quantile scores')
     ylabel = plot_args.get('ylabel', 'Standard uniform quantiles')
     color = plot_args.get('color', 'tab:blue')
+    marker = plot_args.get('marker', 'o')
+    size = plot_args.get('size', 5)
+    legend_loc = plot_args.get('legend_loc', 'best')
 
     # quantiles should be sorted for plotting
     sorted_td = numpy.sort(evaluation_result.test_distribution)
@@ -1238,7 +1241,7 @@ def plot_calibration_test(evaluation_result, axes=None, plot_args=None, show=Fal
         ax = axes
 
     # plot qq plot
-    _ = ax.scatter(sorted_td, pp, label=label, c=color)
+    _ = ax.scatter(sorted_td, pp, label=label, c=color, marker=marker, s=size)
     # plot uncertainty on uniform quantiles
     ax.plot(pp, pp, '-k')
     ax.plot(ulow, pp, ':k')
@@ -1249,7 +1252,7 @@ def plot_calibration_test(evaluation_result, axes=None, plot_args=None, show=Fal
     ax.set_xlabel(xlabel)
     ax.set_ylabel(ylabel)
 
-    ax.legend(loc='lower right')
+    ax.legend(loc=legend_loc)
 
     if show:
         pyplot.show()

--- a/csep/utils/readers.py
+++ b/csep/utils/readers.py
@@ -410,6 +410,7 @@ def csep_ascii(fname, return_catalog_id=False):
     """
 
     def is_header_line(line):
+        # ascii file has csv header with column names as text
         if line[0] == 'lon':
             return True
         else:


### PR DESCRIPTION
- 'Normal' -> 'normal' in catalog test results
- update catalog magnitude test to always return a result object even if no observations occur
- added comment to calibration test to make idx selection more clear
- changed default argument for target_event_rates(scale=True -> False)
- added extra parameters to the plot consistency test plot_args function
