### PR TITLE
fixes issue #80: filter_spatial() not correctly returning region information

### DIFF
--- a/csep/core/catalogs.py
+++ b/csep/core/catalogs.py
@@ -574,7 +574,7 @@ class AbstractBaseCatalog(LoggingMixin):
         else:
             cls = self.__class__
             inst = cls(data=filtered, catalog_id=self.catalog_id, format=self.format, name=self.name,
-                       region=region, compute_stats=update_stats)
+                       region=self.region, compute_stats=update_stats)
             return inst
 
     def apply_mct(self, m_main, event_epoch, mc=2.5):
@@ -854,6 +854,7 @@ class AbstractBaseCatalog(LoggingMixin):
         ax = plot_catalog(self, ax=ax,show=show, extent=extent,
                           set_global=set_global, plot_args=plot_args)
         return ax
+
 
 class CSEPCatalog(AbstractBaseCatalog):
     """

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -122,7 +122,7 @@ class CatalogFiltering(unittest.TestCase):
             # catalog filtered cumulative
             c = comcat.filter([f'magnitude >= {m_min}'], in_place=False)
             # catalog filtered incrementally
-            c_int = comcat.filter([f'magnitude >= {m_min}', f'magnitude < {m_min + 0.09999999}'], in_place=False)
+            c_int = comcat.filter([f'magnitude >= {m_min}', f'magnitude < {m_min + 0.1}'], in_place=False)
             # sum from overall data set
             gs = d.data[:, idm:].sum()
             # incremental counts


### PR DESCRIPTION
- added tests for filtering using simple grid
- added test to ensure region midpoints, idx_map, bbox_mask, and origins are the same