### PR TITLE
added defaults for plot functions. closes #99…

### DIFF
--- a/csep/core/catalogs.py
+++ b/csep/core/catalogs.py
@@ -845,14 +845,33 @@ class AbstractBaseCatalog(LoggingMixin):
         """
         # no mutable function arguments
 
+        plot_args_default = {
+             'basemap': 'ESRI_terrain',
+             'markersize': 2,
+             'markercolor': 'red',
+             'alpha': 0.3,
+             'mag_scale': 7,
+             'legend': True,
+             'grid_labels': True,
+             'legend_loc': 3,
+             'figsize': (8, 8),
+             'title': self.name,
+             'mag_ticks': [4.0, 5.0, 6.0, 7.0]
+        }
+        # Plot the region border (if it exists) by default
+        try:
+            # This will throw error if catalog does not have region
+            _ = self.region.num_nodes
+            plot_args_default['region_border'] = True
+        except AttributeError:
+            pass
 
         plot_args = plot_args or {}
-        plot_args.setdefault('figsize', (10, 10))
-        plot_args.setdefault('title', self.name)
+        plot_args_default.update(plot_args)
 
         # this call requires internet connection and basemap
         ax = plot_catalog(self, ax=ax,show=show, extent=extent,
-                          set_global=set_global, plot_args=plot_args)
+                          set_global=set_global, plot_args=plot_args_default)
         return ax
 
 

--- a/csep/core/forecasts.py
+++ b/csep/core/forecasts.py
@@ -673,10 +673,20 @@ class CatalogForecast(LoggingMixin):
             else:
                 return self.expected_rates
 
-    def plot(self, **kwargs):
+    def plot(self, plot_args = None, **kwargs):
+        plot_args = plot_args or {}
         if self.expected_rates is None:
             self.get_expected_rates()
-        self.expected_rates.plot(**kwargs)
+        args_dict = {'title': self.name,
+                     'grid_labels': True,
+                     'grid': True,
+                     'borders': True,
+                     'feature_lw': 0.5,
+                     'basemap': 'ESRI_terrain',
+                     }
+        args_dict.update(plot_args)
+        ax = self.expected_rates.plot(**kwargs, plot_args=args_dict)
+        return ax
 
     def get_dataframe(self):
         """Return a single dataframe with all of the events from all of the catalogs."""

--- a/csep/utils/calc.py
+++ b/csep/utils/calc.py
@@ -214,3 +214,12 @@ def cleaner_range(start, end, h):
     end = numpy.floor(const * end)
     d = const * h
     return numpy.arange(start, end + d / 2, d) / const
+
+def first_nonnan(arr, axis=0, invalid_val=-1):
+    mask = arr==arr
+    return numpy.where(mask.any(axis=axis), mask.argmax(axis=axis), invalid_val)
+
+def last_nonnan(arr, axis=0, invalid_val=-1):
+    mask = arr==arr
+    val = arr.shape[axis] - numpy.flip(mask, axis=axis).argmax(axis=axis) - 1
+    return numpy.where(mask.any(axis=axis), val, invalid_val)

--- a/docs/concepts/plots.rst
+++ b/docs/concepts/plots.rst
@@ -1,0 +1,27 @@
+.. _plots-reference:
+
+#####
+Plots
+#####
+
+PyCSEP provides several functions to produce commonly used plots, such as an earthquake forecast or the evaluation catalog
+or perhaps a combination of the two.
+
+.. contents:: Table of Contents
+    :local:
+    :depth: 2
+
+************
+Introduction
+************
+
+
+
+**************
+Plot arguments
+**************
+
+***************
+Available plots
+***************
+

--- a/examples/tutorials/catalog_forecast_evaluation.py
+++ b/examples/tutorials/catalog_forecast_evaluation.py
@@ -33,8 +33,8 @@ from csep.utils import datasets, time_utils
 # Forecasts should define a time horizon in which they are valid. The choice is flexible for catalog-based forecasts, because
 # the catalogs can be filtered to accommodate multiple end-times. Conceptually, these should be separate forecasts.
 
-start_time = time_utils.strptime_to_utc_datetime("1992-06-28 11:57:34.14")
-end_time = time_utils.strptime_to_utc_datetime("1992-07-28 11:57:34.14")
+start_time = time_utils.strptime_to_utc_datetime("1992-06-28 11:57:35.0")
+end_time = time_utils.strptime_to_utc_datetime("1992-07-28 11:57:35.0")
 
 ####################################################################################################################################
 # Define spatial and magnitude regions
@@ -72,7 +72,8 @@ space_magnitude_region = regions.create_space_magnitude_region(region, magnitude
 
 forecast = csep.load_catalog_forecast(datasets.ucerf3_ascii_format_landers_fname,
                                       start_time = start_time, end_time = end_time,
-                                      region = space_magnitude_region)
+                                      region = space_magnitude_region,
+                                      apply_filters = True)
 
 # Assign filters to forecast
 forecast.filters = [f'origin_time >= {forecast.start_epoch}', f'origin_time < {forecast.end_epoch}']
@@ -92,7 +93,12 @@ forecast.filters = [f'origin_time >= {forecast.start_epoch}', f'origin_time < {f
 comcat_catalog = csep.query_comcat(start_time, end_time, min_magnitude=forecast.min_magnitude)
 
 # Filter observed catalog using the same region as the forecast
+
 comcat_catalog = comcat_catalog.filter_spatial(forecast.region)
+print(comcat_catalog)
+
+# Plot the catalog
+comcat_catalog.plot()
 
 ####################################################################################################################################
 # Perform number test


### PR DESCRIPTION
… and closes #95.

- added defaults for plot catalog to make the basic plot look prettier
- added defaults for forecast plots
- forecast.plot() properly returns the figure axes
- added function to compute tight_bbox around region
- added option region_border to plot tight bbox around regions in catalog plots
- added option region_border to plot tight boox around region in forecast plots
- added start of plots.rst for more in-depth documentation on plotting
- fixes the catalog evaluation example. closes #99