### PR TITLE
fixes apply_filter and makes CL and L test use the same region as catalog if not defined

### DIFF
--- a/csep/__init__.py
+++ b/csep/__init__.py
@@ -13,6 +13,8 @@ from csep.core.repositories import (
     write_json
 )
 
+from csep.core.exceptions import CSEPCatalogException
+
 from csep.utils import datasets
 from csep.utils import readers
 
@@ -112,10 +114,12 @@ def load_catalog(filename, type='csep-csv', format='native', loader=None, apply_
         format (str): ('native', 'csep') determines whether the catalog should be converted into the csep
                       formatted catalog or kept as native.
         apply_filters (bool): if true, will apply filters and spatial filter to catalog. time-varying magnitude completeness
-                              will still need to be applied.
+                              will still need to be applied. filters kwarg should be included. see catalog
+                              documentation for more details.
 
     Returns (:class:`~csep.core.catalogs.AbstractBaseCatalog`)
     """
+
 
     if type not in ('ucerf3', 'csep-csv', 'zmap', 'jma-csv', 'ingv_horus', 'ingv_emrcmt', 'ndk') and loader is None:
         raise ValueError("type must be one of the following: ('ucerf3', 'csep-csv', 'zmap', 'jma-csv', 'ndk', 'ingv_horus', 'ingv_emrcmt').")
@@ -172,7 +176,10 @@ def load_catalog(filename, type='csep-csv', format='native', loader=None, apply_
         raise ValueError('format must be either "native" or "csep"')
 
     if apply_filters:
-        return_val = return_val.filter().filter_spatial()
+        try:
+            return_val = return_val.filter().filter_spatial()
+        except CSEPCatalogException:
+            return_val = return_val.filter()
 
     return return_val
 

--- a/csep/__init__.py
+++ b/csep/__init__.py
@@ -217,7 +217,10 @@ def query_comcat(start_time, end_time, min_magnitude=2.50,
     print("Fetched ComCat catalog in {} seconds.\n".format(t1 - t0))
 
     if apply_filters:
-        comcat = comcat.filter().filter_spatial()
+        try:
+            comcat = comcat.filter().filter_spatial()
+        except CSEPCatalogException:
+            comcat = comcat.filter()
 
     if verbose:
         print("Downloaded catalog from ComCat with following parameters")

--- a/csep/core/catalogs.py
+++ b/csep/core/catalogs.py
@@ -744,7 +744,7 @@ class AbstractBaseCatalog(LoggingMixin):
         if self.region is None:
             raise CSEPCatalogException("Cannot create binned rates without region information.")
 
-        if self.region.magnitudes is None or mag_bins is None:
+        if self.region.magnitudes is None and mag_bins is None:
             raise CSEPCatalogException("Region must have magnitudes or mag_bins must be defined to "
                                        "compute space magnitude binning.")
 

--- a/csep/core/catalogs.py
+++ b/csep/core/catalogs.py
@@ -744,23 +744,19 @@ class AbstractBaseCatalog(LoggingMixin):
         if self.region is None:
             raise CSEPCatalogException("Cannot create binned rates without region information.")
 
+        if self.region.magnitudes is None or mag_bins is None:
+            raise CSEPCatalogException("Region must have magnitudes or mag_bins must be defined to "
+                                       "compute space magnitude binning.")
+
         # short-circuit if zero-events in catalog... return array of zeros
         if self.event_count == 0:
             n_poly = self.region.num_nodes
             n_mws = self.region.num_mag_bins
             output = numpy.zeros((n_poly, n_mws))
             skipped = []
-
         else:
             if mag_bins is None:
-                try:
-                    # a forecast is a type of region, but region does not need a magnitude
-                    mag_bins = self.region.magnitudes
-                except AttributeError:
-                    # use default magnitude bins from csep
-                    mag_bins = CSEP_MW_BINS
-                    self.region.magnitudes = mag_bins
-                    self.region.num_mag_bins = len(mag_bins)
+                mag_bins = self.region.magnitudes
 
             # compute if not
             # todo: this should be routed through self.region to allow for different types of regions

--- a/csep/core/poisson_evaluations.py
+++ b/csep/core/poisson_evaluations.py
@@ -6,6 +6,7 @@ import scipy.stats
 
 from csep.models import EvaluationResult
 from csep.utils.stats import poisson_joint_log_likelihood_ndarray
+from csep.core.exceptions import CSEPCatalogException
 
 
 def paired_t_test(forecast, benchmark_forecast, observed_catalog, alpha=0.05, scale=False):
@@ -174,7 +175,12 @@ def conditional_likelihood_test(gridded_forecast, observed_catalog, num_simulati
     """
 
     # grid catalog onto spatial grid
+    try:
+        _ = observed_catalog.region.magnitudes
+    except CSEPCatalogException:
+        observed_catalog.region = gridded_forecast.region
     gridded_catalog_data = observed_catalog.spatial_magnitude_counts()
+
 
     # simply call likelihood test on catalog data and forecast
     qs, obs_ll, simulated_ll = _poisson_likelihood_test(gridded_forecast.data, gridded_catalog_data,
@@ -304,6 +310,11 @@ def likelihood_test(gridded_forecast, observed_catalog, num_simulations=1000, se
     """
 
     # grid catalog onto spatial grid
+    # grid catalog onto spatial grid
+    try:
+        _ = observed_catalog.region.magnitudes
+    except CSEPCatalogException:
+        observed_catalog.region = gridded_forecast.region
     gridded_catalog_data = observed_catalog.spatial_magnitude_counts()
 
     # simply call likelihood test on catalog and forecast


### PR DESCRIPTION
- fixes #83 and fixes #94  
- spatial_magnitude_counts() now throws error if magnitude bins are not defined.
- remove default bins in spatial_magnitude_counts()
- CL test and L test now share region with the catalog if not defined
- load_catalog() function now properly handles the apply_filter case where spatial region is not defined