### PR TITLE
Fix lat-to-lon aspect ratio (now for real)

### DIFF
--- a/csep/utils/plots.py
+++ b/csep/utils/plots.py
@@ -584,7 +584,7 @@ def plot_basemap(basemap, extent, ax=None,  coastline=True, borders=False, linec
             # Set plot aspect according to local longitude-latitude ratio in metric units
             # (only compatible with plain PlateCarree "projection")
             LATKM = 110.574  # length of a ° of latitude [km]; constant --> ignores Earth's flattening
-            ax.set_aspect(111.320 / LATKM / numpy.cos(numpy.deg2rad(central_latitude)))
+            ax.set_aspect(LATKM / (111.320 * numpy.cos(numpy.deg2rad(central_latitude))))
         else:
             fig = pyplot.figure()
             ax = fig.add_subplot(111, projection=projection)


### PR DESCRIPTION
As noted in https://github.com/SCECcode/pycsep/pull/125#issuecomment-857450014, the calculation of the aspect ratio for the 'fast' projection plotting option was still not correct. This PR fixes this.

To summarize:
- original (issue #109): `1 / (LATKM / 111.320 * np.cos(np.deg2rad(lat_region)))` -- WRONG (but almost correct)
- simplification (PR #110): `111.320 * np.cos(np.deg2rad(lat_region)) / LATKM` -- VERY WRONG
- simplification (PR #125): `111.320 / LATKM / np.cos(np.deg2rad(lat_region))` -- WRONG (but almost correct)
- correct (this PR) `LATKM / (111.320 * np.cos(np.deg2rad(lat_region)))`

Apologies for the multiple confusions! Next time, I will do the maths first... 😉 
