### PR TITLE
fix: region border plot

### DIFF
--- a/csep/core/forecasts.py
+++ b/csep/core/forecasts.py
@@ -397,22 +397,23 @@ class GriddedForecast(MarkedGriddedDataSet):
         data = numpy.loadtxt(ascii_fname)
         # this is very ugly, but since unique returns a sorted list, we want to get the index, sort that and then return
         # from the original array. same for magnitudes below.
-        all_polys = data[:,:4]
-        all_poly_mask = data[:,-1]
+        all_polys = data[:, :4]
+        all_poly_mask = data[:, -1]
         sorted_idx = numpy.sort(numpy.unique(all_polys, return_index=True, axis=0)[1], kind='stable')
         unique_poly = all_polys[sorted_idx]
         # gives the flag for a spatial cell in the order it was presented in the file
         poly_mask = all_poly_mask[sorted_idx]
         # create magnitudes bins using Mag_0, ignoring Mag_1 bc they are regular until last bin. we dont want binary search for this
-        all_mws = data[:,-4]
+        all_mws = data[:, -4]
         sorted_idx = numpy.sort(numpy.unique(all_mws, return_index=True)[1], kind='stable')
         mws = all_mws[sorted_idx]
         # csep1 stores the lat lons as min values and not (x,y) tuples
-        bboxes = [tuple(itertools.product(bbox[:2], bbox[2:])) for bbox in unique_poly]
         if swap_latlon:
-            bboxes = [tuple(itertools.product(bbox[2:], bbox[:2])) for bbox in unique_poly]
+            bboxes = [((i[2], i[0]), (i[3], i[0]), (i[3], i[1]), (i[2], i[1])) for i in unique_poly]
+        else:
+            bboxes = [((i[0], i[2]), (i[0], i[3]), (i[1], i[3]), (i[1], i[2])) for i in unique_poly]
         # the spatial cells are arranged fast in latitude, so this only works for the specific csep1 file format
-        dh = float(unique_poly[0,3] - unique_poly[0,2])
+        dh = float(unique_poly[0, 3] - unique_poly[0, 2])
         # create CarteisanGrid of points
         region = CartesianGrid2D([Polygon(bbox) for bbox in bboxes], dh, mask=poly_mask)
         # get dims of 2d np.array

--- a/csep/core/regions.py
+++ b/csep/core/regions.py
@@ -8,6 +8,8 @@ from xml.etree import ElementTree as ET
 import numpy
 import numpy as np
 import mercantile
+from shapely import geometry
+from shapely.ops import unary_union
 
 # PyCSEP imports
 from csep.utils.calc import bin1d_vec, cleaner_range, first_nonnan, last_nonnan
@@ -723,34 +725,13 @@ class CartesianGrid2D:
         return a, xs, ys
 
     def tight_bbox(self):
-        # creates tight bounding box around the region, probably a faster way to do this.
-        ny, nx = self.idx_map.shape
-        asc = []
-        desc = []
-        for j in range(ny):
-            row = self.idx_map[j, :]
-            argmin = first_nonnan(row)
-            argmax = last_nonnan(row)
-            # points are stored clockwise
-            poly_min = self.polygons[int(row[argmin])].points
-            asc.insert(0, poly_min[0])
-            asc.insert(0, poly_min[1])
-            poly_max = self.polygons[int(row[argmax])].points
-            lat_0 = poly_max[2][1]
-            lat_1 = poly_max[3][1]
-            # last two points are 'right hand side of polygon'
-            if lat_0 < lat_1:
-                desc.append(poly_max[2])
-                desc.append(poly_max[3])
-            else:
-                desc.append(poly_max[3])
-                desc.append(poly_max[2])
-        # close the loop
-        poly = np.array(asc + desc)
-        sorted_idx = np.sort(np.unique(poly, return_index=True, axis=0)[1], kind='stable')
-        unique_poly = poly[sorted_idx]
-        unique_poly = np.append(unique_poly, [unique_poly[0, :]], axis=0)
-        return unique_poly
+        # creates tight bounding box around the region
+
+        polys = [geometry.Polygon([(np.round(j[0], 2), np.round(j[1], 2)) for j in i.points]) for i in self.polygons]
+        joined_poly = unary_union(polys)
+        bounds = np.array([i for i in joined_poly.boundary.xy]).T
+
+        return bounds
 
     def get_cell_area(self):
         """ Compute the area of each polygon in sq. kilometers.

--- a/csep/core/regions.py
+++ b/csep/core/regions.py
@@ -724,11 +724,16 @@ class CartesianGrid2D:
 
         return a, xs, ys
 
-    def tight_bbox(self):
+    def tight_bbox(self, precision=4):
         # creates tight bounding box around the region
+        poly = np.array([i.points for i in self.polygons])
 
-        polys = [geometry.Polygon([(np.round(j[0], 2), np.round(j[1], 2)) for j in i.points]) for i in self.polygons]
-        joined_poly = unary_union(polys)
+        sorted_idx = np.sort(np.unique(poly, return_index=True, axis=0)[1], kind='stable')
+        unique_poly = poly[sorted_idx]
+
+        # merges all the cell polygons into one
+        polygons = [geometry.Polygon(np.round(i, precision)) for i in unique_poly]
+        joined_poly = unary_union(polygons)
         bounds = np.array([i for i in joined_poly.boundary.xy]).T
 
         return bounds

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ matplotlib
 cartopy
 obspy
 pyproj
+shapely
 python-dateutil
 pytest
 vcrpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,11 +5,11 @@ matplotlib
 cartopy
 obspy
 pyproj
-shapely
 python-dateutil
 pytest
 vcrpy
 pytest-cov
+shapely
 sphinx
 sphinx-gallery
 sphinx-rtd-theme

--- a/requirements.yml
+++ b/requirements.yml
@@ -13,6 +13,7 @@ dependencies:
   - python-dateutil
   - pytest
   - cartopy
+  - shapely
   - sphinx
   - sphinx-gallery
   - sphinx_rtd_theme

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ setup(
         'obspy',
         'pyproj',
         'python-dateutil',
-        'mercantile'
+        'mercantile',
+        'shapely'
     ],
     extras_require = {
         'test': [


### PR DESCRIPTION
fixes #197.  Now uses shapely to merge all cell polygons into one, and extract the borders. Floating point issues with coincident cell edges are sorted out by rounding up to 2 decimals.

# pyCSEP Pull Request Checklist

Please check out the [contributing guidelines](https://github.com/SCECcode/pycsep/blob/master/CONTRIBUTING.md) for some tips 
on making pull requests to pyCSEP. 

Fixes issue #197 #200.

## Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
