### PR TITLE
Fix consistency plots

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 scipy
 pandas
-matplotlib<=3.5.3
+matplotlib
 cartopy
 obspy
 pyproj

--- a/requirements.yml
+++ b/requirements.yml
@@ -7,7 +7,7 @@ dependencies:
   - numpy
   - pandas
   - scipy
-  - matplotlib<=3.5.3
+  - matplotlib
   - pyproj
   - obspy
   - python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         'numpy',
         'scipy',
         'pandas',
-        'matplotlib<=3.5.3',
+        'matplotlib',
         'cartopy',
         'obspy',
         'pyproj',


### PR DESCRIPTION
fixes #203.  Replaces the use of the observed statistic to plot confidence intervals by using error plots. Instead, uses the mean of the distribution, whereas the observed statistic if plot separately.  Also, provides the option to plot the mean as a black dot. This change fixes the issue, while I expect to refactor the plotting code for version 0.7.0

 
## Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
