### PR TITLE
Fixed negative timestamps parsing for windows

### DIFF
--- a/csep/utils/time_utils.py
+++ b/csep/utils/time_utils.py
@@ -1,6 +1,7 @@
 import calendar
 import datetime
 import re
+import os
 import warnings
 from csep.utils.constants import SECONDS_PER_ASTRONOMICAL_YEAR, SECONDS_PER_DAY
 
@@ -17,8 +18,25 @@ def epoch_time_to_utc_datetime(epoch_time_milli):
     """
     if epoch_time_milli is None:
         return epoch_time_milli
+
     epoch_time = epoch_time_milli / 1000
-    dt = datetime.datetime.fromtimestamp(epoch_time, datetime.timezone.utc)
+
+    if os.name == "nt" and epoch_time < 0:
+
+        if isinstance(epoch_time, int):
+            sec = epoch_time
+            milli_sec = 0
+        else:
+            whole, frac = str(epoch_time).split(".")
+            sec = int(whole)
+            milli_sec = int(frac) * -1
+        dt = datetime.datetime(1970, 1, 1) + datetime.timedelta(
+                                    seconds=sec,
+                                    milliseconds=milli_sec
+                                    )
+    else:
+        dt = datetime.datetime.fromtimestamp(epoch_time, datetime.timezone.utc)
+
     return dt
 
 def datetime_to_utc_epoch(dt):

--- a/tests/test_time_utilities.py
+++ b/tests/test_time_utilities.py
@@ -50,5 +50,8 @@ class TestTimeUtilities(TestCase):
         test_year = decimal_year(epoch_time_to_utc_datetime(epoch))
         self.assertAlmostEqual(year, test_year)
 
-
-
+    def test_negative_epoch(self):
+        year = 1969.12315213421321321
+        epoch = decimal_year_to_utc_epoch(year)
+        test_year = decimal_year(epoch_time_to_utc_datetime(epoch))
+        self.assertAlmostEqual(year, test_year)


### PR DESCRIPTION
Added a bypass of time_utils for Windows OS users, which creates datetime objects from negative timestamps/epochs.


## Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
