### PR TITLE
fix: handles BSI query URL exception or SSL errors for python 3.8 to 3.11

### DIFF
--- a/csep/utils/comcat.py
+++ b/csep/utils/comcat.py
@@ -313,7 +313,8 @@ def _search(**newargs):
 
     except URLError as URLe:
         # Fails to verify SSL certificate, when there is a hostname mismatch
-        if isinstance(URLe.reason, ssl.SSLCertVerificationError) and URLe.reason.verify_code == 62:
+        if (isinstance(URLe.reason, ssl.SSLCertVerificationError) and URLe.reason.verify_code == 62) \
+                or (isinstance(URLe.reason, ssl.SSLError) and URLe.reason.errno == 5):
             try:
                 context = ssl._create_unverified_context()
                 fh = request.urlopen(url, timeout=TIMEOUT, context=context)


### PR DESCRIPTION
The handling of exceptions to query the Italy BSI catalog (due to SSL certificates not being quite alright on their API) must be different from python  3.8 and 3.11 In 3.8, the reason is thrown as a ssl.SSLCertVerificationErros, whereas in 3.11 it is thrown just as a ssl.SSLError, both of which has different codes or error numbers. 
Fixed that issue, to the query works for python versions from 3.8 up to 3.11



## Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
