### PR TITLE
Fix writing catalog csv files on Windows

### DIFF
--- a/csep/core/catalogs.py
+++ b/csep/core/catalogs.py
@@ -325,7 +325,7 @@ class AbstractBaseCatalog(LoggingMixin):
             write_string = 'a'
         else:
             write_string = 'w'
-        with open(filename, write_string) as outfile:
+        with open(filename, write_string, newline='') as outfile:
             writer = csv.DictWriter(outfile, fieldnames=header, delimiter=',')
             if write_header:
                 writer.writeheader()


### PR DESCRIPTION
**Problem**: on Windows, `csep.catalogs.AbstractBaseCatalog.write_ascii()` interleaves every entry with an empty line, like so.:
```
lon,lat,mag,time_string,depth,catalog_id,event_id

-115.2228333,32.3463333,3.99,2005-01-02T20:58:48.280000,5.987,,ci10070917

-117.4448333,34.1238333,4.42,2005-01-06T14:35:27.680000,6.148,,ci14116972
```
Those files can also not be read by `csep.load_catalog()` (`IndexError: list index out of range`)

**Solution**: add `newline=''` to `open(filename, write_string)`, see [docs.python.org/3/library/csv (footnote)](https://docs.python.org/3/library/csv.html#id3) and [stackoverflow.com/a/3348664](https://stackoverflow.com/a/3348664)

**FYI**: `.write_json()` is not affected, and there is no further occurrence in pyCSEP that needs to be fixed (b/c there is no further use of `csv.DictWriter` or `csv.writer`).

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
