### PR TITLE
fix: tutorial for plot_customizations.  Changed projection to have a …

### DIFF
--- a/examples/tutorials/plot_customizations.py
+++ b/examples/tutorials/plot_customizations.py
@@ -107,7 +107,7 @@ rate_sum = forecast.region.get_cartesian(rate_sum)
 # We define the arguments and a global projection, centered at $lon=-180$
 
 plot_args = {'figsize': (10,6), 'coastline':True, 'feature_color':'black',
-             'projection': cartopy.crs.Robinson(central_longitude=-179.0),
+             'projection': cartopy.crs.Robinson(central_longitude=180.0),
              'title': forecast.name, 'grid_labels': False,
              'cmap': 'magma',
              'clabel': r'$\log_{10}\lambda\left(M_w \in [{%.2f},\,{%.2f}]\right)$ per '
@@ -119,9 +119,9 @@ plot_args = {'figsize': (10,6), 'coastline':True, 'feature_color':'black',
 # To plot a global forecast, we must assign the option ``set_global=True``, which is required by :ref:cartopy to handle
 # internally the extent of the plot
 
-# ax = plots.plot_spatial_dataset(numpy.log10(rate_sum), forecast.region,
-#                                show=True, set_global=True,
-#                                plot_args=plot_args)
+ax = plots.plot_spatial_dataset(numpy.log10(rate_sum), forecast.region,
+                               show=True, set_global=True,
+                               plot_args=plot_args)
 
 ####################################################################################################################################
 


### PR DESCRIPTION
Fixes #241: tutorial/plot_customization.py . It placed back central_longitude=180 as it was originally. Now using -179 breaks it, but that value was never intended.

# pyCSEP Pull Request Checklist

## Type of change:

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
