### PR TITLE
fix: negbinom consistency plots now have the correct boundaries

### DIFF
--- a/csep/utils/plots.py
+++ b/csep/utils/plots.py
@@ -1856,9 +1856,9 @@ def plot_consistency_test(eval_results, normalize=False, axes=None,
             mean = res.test_distribution[1]
             upsilon = 1.0 - ((var - mean) / var)
             tau = (mean ** 2 / (var - mean))
-            phigh = scipy.stats.nbinom.ppf((1 - percentile / 100.) / 2., tau,
+            plow = scipy.stats.nbinom.ppf((1 - percentile / 100.) / 2., tau,
                                            upsilon)
-            plow = scipy.stats.nbinom.ppf(1 - (1 - percentile / 100.) / 2.,
+            phigh = scipy.stats.nbinom.ppf(1 - (1 - percentile / 100.) / 2.,
                                           tau, upsilon)
 
         # empirical distributions


### PR DESCRIPTION
Fixes #236 typo/error in poisson_consistency_test that made negativebinomial critical intervals being reversely assigned, thus creating error with matplotlib.

# pyCSEP Pull Request Checklist
## Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
