### PR TITLE
Updated pycsep requirements for pip installation & ga using pip

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -48,7 +48,7 @@ jobs:
 
 
   build_pip:
-#    if: github.repository == 'SCECcode/pycsep'
+    if: github.repository == 'SCECcode/pycsep'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -45,3 +45,32 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
         run: |
           bash <(curl -s https://codecov.io/bash) || echo 'Codecov failed to upload'
+
+
+  build_pip:
+#    if: github.repository == 'SCECcode/pycsep'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.9']
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: Install pyCSEP
+        run: |
+          pip install -e .
+          python -c "import csep; print('Version: ', csep.__version__)"
+
+      - name: Test with pytest
+        run: |
+          pip install vcrpy==4.3.1 pytest pytest-cov
+          pytest --cov=./ --cov-config=.coveragerc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+## Build the docker image using:
+# docker build --build-arg USERNAME=$USER --build-arg USER_UID --no-cache -t pycsep .
+
+## Docker instructions
+
+# Install Docker image from trusted source
+FROM python:3.9.18-slim-bullseye
+
+# Setup user id and permissions.
+ARG USERNAME=modeler
+ARG USER_UID=1100
+ARG USER_GID=$USER_UID
+RUN groupadd --non-unique -g $USER_GID $USERNAME \
+    && useradd -u $USER_UID -g $USER_GID -s /bin/sh -m $USERNAME
+
+# Install git
+RUN apt update
+RUN apt install -y git
+
+# Set up work directory in the Docker container.
+WORKDIR /usr/src/
+
+# Set up and create python virtual environment
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Install pycsep.
+RUN git clone https://github.com/SCECcode/pycsep.git
+RUN pip install --no-cache-dir --upgrade pip
+RUN cd pycsep && pip install .
+
+# Docker can now be initialized as user
+USER $USERNAME
+
+## Run the docker image in interactive mode from the command line
+# docker run -it --rm --name pycsep pycsep:latest
+

--- a/README.md
+++ b/README.md
@@ -36,13 +36,11 @@ pyCSEP can be installed in several ways. It can be installed using conda or pip 
 source code found in the pyCSEP github repo. Researchers interested in contributing to pyCSEP development should 
 install pyCSEP from source code. pyCSEP depends on the following software packages. 
 These which may be installed automatically, or manually, depending on the installation method used.
-* Python 3.7 or later (https://python.org)
+* Python 3.9 or later (https://python.org)
 * NumPy 1.21.3 or later (https://numpy.org)
 * SciPy 1.7.1 or later (https://scipy.org)
 * pandas 1.3.4 or later (https://pandas.pydata.org)
-* cartopy 0.20.0 or later (https://scitools.org.uk/cartopy/docs/latest)
-* GEOS 3.7.2 or later (https://trac.osgeo.org/geos/)
-* PROJ 8.0.0 or later (https://proj.org/)
+* cartopy 0.22.0 or later (https://scitools.org.uk/cartopy/docs/latest)
 
 Please see the [requirements file](https://github.com/SCECcode/pycsep/blob/master/requirements.yml) for a complete list 
 of requirements. These are installed automatically when using the `conda` distribution.

--- a/docs/getting_started/installing.rst
+++ b/docs/getting_started/installing.rst
@@ -5,7 +5,7 @@ We are working on a ``conda-forge`` recipe and PyPI distribution.
 If you plan on contributing to this package, visit the
 `contribution guidelines <https://github.com/SCECcode/pycsep/blob/master/CONTRIBUTING.md>`_ for installation instructions.
 
-.. note:: This package requires >=Python 3.7.
+.. note:: This package requires >=Python 3.9.
 
 The easiest way to install PyCSEP is using ``conda``. It can also be installed using ``pip`` or built from source.
 
@@ -22,29 +22,25 @@ Before this installation will work, you must **first** install the following sys
 should be installed by the installation script. To help manage dependency issues, we recommend using virtual environments
 like `virtualenv`.
 
-| Python 3.7 or later (https://python.org)
+| Python 3.9 or later (https://python.org)
 |
-| NumPy 1.10 or later (https://numpy.org)
+| NumPy 1.21.3 or later (https://numpy.org)
 |     Python package for scientific computing and numerical calculations.
 |
-| GEOS 3.3.3 or later (https://trac.osgeo.org/geos/)
-|     C++ library for processing geometry.
+| SciPy 1.7.1 or later (https://scipy.org)
+|     Python package that extends NumPy tools.
 |
-| PROJ 4.9.0 or later (https://proj4.org/)
-|     Library for cartographic projections.
+| Pandas 1.3.4 or later (https://pandas.pydata.org)
+|     Python package for data analysis and manipulation.
+|
+| Cartopy 0.22.0 or later (https://scitools.org.uk/cartopy/)
+|     Python package for geospatial data processing.
 
-Example for Ubuntu: ::
+Example for Ubuntu and MacOS: ::
 
-    sudo apt-get install libproj-dev proj-data proj-bin
-    sudo apt-get install libgeos-dev
+    git clone https://github.com/sceccode/pycsep
     pip install --upgrade pip
-    pip install numpy
-
-Example for MacOS: ::
-
-    brew install proj geos
-    pip install --upgrade pip
-    pip install numpy
+    pip install -e .
 
 Installing from Source
 ----------------------
@@ -54,13 +50,13 @@ the latest GitHub commit.
 
 We recommend using virtual environments when installing python packages from source to avoid any dependency conflicts. We prefer
 ``conda`` as the package manager over ``pip``, because ``conda`` does a good job of handling binary distributions of packages
-across multiple platforms. Also, we recommend using the ``miniconda`` installer, because it is lightweight and only includes
+across multiple platforms. Also, we recommend using the ``miniconda`` or the ``miniforge`` (which uses mamba for a faster dependency handling) installers, because it is lightweight and only includes
 necessary pacakages like ``pip`` and ``zlib``.
 
 Using Conda
 ***********
 
-If you don't have ``conda`` on your machine, download and install `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_. ::
+If you don't have ``conda`` on your machine, download and install `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_ or `Miniforge <https://github.com/conda-forge/miniforge>`_ ::
 
     git clone https://github.com/SCECcode/pycsep
     cd pycsep


### PR DESCRIPTION
pip installation was difficult before because cartopy required the system libraries ``geos`` and ``proj``. However, from version 0.22.0, cartopy comes with its own wheels to handle those binaries. I updated the reqs by removing geos and proj, but updated the python required version to 3.9. 

The github actions for the pycsep-tests and docs were already tested on my fork. Also, added a Dockerfile to create a pycsep image
 

# pyCSEP Pull Request Checklist

Please check out the [contributing guidelines](https://github.com/SCECcode/pycsep/blob/master/CONTRIBUTING.md) for some tips 
on making pull requests to pyCSEP. 

Fixes issue #(*please fill in or delete if not needed*).

## Type of change:

Please delete options that are not relevant.

- [x] Documentation update (this pull request adds no new code)
- [x] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
