### PR TITLE
Fix and optimize `bin1d_vec` + extend units tests + fix imprecise bin edge creation

### DIFF
--- a/csep/core/catalogs.py
+++ b/csep/core/catalogs.py
@@ -395,7 +395,7 @@ class AbstractBaseCatalog(LoggingMixin):
     def get_mag_idx(self):
         """ Return magnitude index from region magnitudes """
         try:
-            return bin1d_vec(self.get_magnitudes(), self.region.magnitudes, tol=0.00001, right_continuous=True)
+            return bin1d_vec(self.get_magnitudes(), self.region.magnitudes, right_continuous=True)
         except AttributeError:
             raise CSEPCatalogException("Cannot return magnitude index without self.region.magnitudes")
 
@@ -699,7 +699,7 @@ class AbstractBaseCatalog(LoggingMixin):
         event_flag[idx] = 1
         return event_flag
 
-    def magnitude_counts(self, mag_bins=None, tol=0.00001, retbins=False):
+    def magnitude_counts(self, mag_bins=None, tol=None, retbins=False):
         """ Computes the count of events within mag_bins
 
 
@@ -734,7 +734,7 @@ class AbstractBaseCatalog(LoggingMixin):
         else:
             return out
 
-    def spatial_magnitude_counts(self, mag_bins=None, tol=0.00001):
+    def spatial_magnitude_counts(self, mag_bins=None, tol=None):
         """ Return counts of events in space-magnitude region.
 
         We figure out the index of the polygons and create a map that relates the spatial coordinate in the

--- a/csep/core/catalogs.py
+++ b/csep/core/catalogs.py
@@ -700,15 +700,20 @@ class AbstractBaseCatalog(LoggingMixin):
         return event_flag
 
     def magnitude_counts(self, mag_bins=None, tol=None, retbins=False):
-        """ Computes the count of events within mag_bins
-
+        """ Computes the count of events within magnitude bins
 
         Args:
-            mag_bins: uses csep.utils.constants.CSEP_MW_BINS as default magnitude bins
-            retbins (bool): if this is true, return the bins used
+            mag_bins (array-like): magnitude bin edges, by default tries to use magnitude bin edges
+                                   associated with region, otherwise :data:`csep.utils.constants.CSEP_MW_BINS`
+            tol (float): overwrite numerical tolerance, by default determined automatically from the
+                         magnitudes' dtype to account for the limited precision of floating-point values.
+                         Only necessary to specify if the magnitudes were subject to some
+                         floating-point operations after loading or generating them
+                         (increased roundoff error, see :func:`csep.utils.calc.bin1d_vec`).
+            retbins (bool): if true, return the used bins in a tuple together with the counts.
 
         Returns:
-            numpy.ndarray: showing the counts of hte events in each magnitude bin
+            numpy.ndarray: events counts in each magnitude bin
         """
         # todo: keep track of events that are ignored
         if mag_bins is None:
@@ -735,17 +740,23 @@ class AbstractBaseCatalog(LoggingMixin):
             return out
 
     def spatial_magnitude_counts(self, mag_bins=None, tol=None):
-        """ Return counts of events in space-magnitude region.
+        """ Return counts of events in space-magnitude bins.
 
-        We figure out the index of the polygons and create a map that relates the spatial coordinate in the
-        Cartesian grid with the polygon in region.
+        It figures out the index of the polygons and maps the spatial coordinates in the Cartesian
+        grid with the polygon in region.
 
         Args:
-            mag_bins (list, numpy.array): magnitude bins (optional), if empty tries to use magnitude bins associated with region
-            tol (float): tolerance for comparisons within magnitude bins
+            mag_bins (array-like): magnitude bin edges (optional), by default uses magnitude bin edges
+                                   associated with region.
+            tol (float): overwrite numerical tolerance, by default determined automatically from the
+                         magnitudes' dtype to account for the limited precision of floating-point values.
+                         Only necessary to specify if the magnitudes were subject to some
+                         floating-point operations after loading or generating them
+                         (increased roundoff error, see :func:`csep.utils.calc.bin1d_vec`).
 
         Returns:
-            output: unnormalized event count in each bin, 1d ndarray where index corresponds to midpoints
+            numpy.ndarray: unnormalized event count in each space-magnitude bin (2d, with indices
+                           corresponding to spatial midpoints and magnitude bin, respectively)
 
         """
         # make sure region is specified with catalog

--- a/csep/core/forecasts.py
+++ b/csep/core/forecasts.py
@@ -219,10 +219,15 @@ class MarkedGriddedDataSet(GriddedDataSet):
         Note: the right-most bin is treated as extending to infinity.
 
         Args:
-            mags (array-like): list of magnitudes
+            mags (array-like): magnitudes bin edges.
+            tol (float): overwrite numerical tolerance, by default determined automatically from the
+                         magnitudes' dtype to account for the limited precision of floating-point values.
+                         Only necessary to specify if the magnitudes were subject to some
+                         floating-point operations after loading or generating them
+                         (increased roundoff error, see :func:`csep.utils.calc.bin1d_vec`).
 
         Returns:
-            idm (array-like): indices corresponding to mags
+            numpy.ndarray: indices corresponding to the magnitude bins
 
         Raises:
             ValueError

--- a/csep/core/forecasts.py
+++ b/csep/core/forecasts.py
@@ -213,7 +213,7 @@ class MarkedGriddedDataSet(GriddedDataSet):
         """ Returns counts of events in magnitude bins """
         return numpy.sum(self.data, axis=0)
 
-    def get_magnitude_index(self, mags, tol=0.00001):
+    def get_magnitude_index(self, mags, tol=None):
         """ Returns the indices into the magnitude bins of selected magnitudes
 
         Note: the right-most bin is treated as extending to infinity.

--- a/csep/core/regions.py
+++ b/csep/core/regions.py
@@ -313,12 +313,7 @@ def magnitude_bins(start_magnitude, end_magnitude, dmw):
     Returns:
         bin_edges (numpy.ndarray)
     """
-    # convert to integers to prevent accumulating floating point errors
-    const = 10000
-    start = numpy.floor(const * start_magnitude)
-    end = numpy.floor(const * end_magnitude)
-    d = const * dmw
-    return numpy.arange(start, end + d / 2, d) / const
+    return cleaner_range(start_magnitude, end_magnitude, dmw)
 
 def create_space_magnitude_region(region, magnitudes):
     """Simple wrapper to create space-magnitude region """

--- a/csep/core/regions.py
+++ b/csep/core/regions.py
@@ -625,8 +625,8 @@ class CartesianGrid2D:
         Returns:
             idx: ndarray-like
         """
-        idx = bin1d_vec(numpy.array(lons), self.xs)
-        idy = bin1d_vec(numpy.array(lats), self.ys)
+        idx = bin1d_vec(lons, self.xs)
+        idy = bin1d_vec(lats, self.ys)
         if numpy.any(idx == -1) or numpy.any(idy == -1):
             raise ValueError("at least one lon and lat pair contain values that are outside of the valid region.")
         if numpy.any(self.bbox_mask[idy, idx] == 1):
@@ -1061,7 +1061,7 @@ class QuadtreeGrid2D:
         self.cell_area = cell_area
         return self.cell_area
 
-    def get_index_of(self, lons, lats): 
+    def get_index_of(self, lons, lats):
         """ Returns the index of lons, lats in self.polygons
 
         Args:

--- a/csep/core/regions.py
+++ b/csep/core/regions.py
@@ -495,7 +495,7 @@ def compute_vertices(origin_points, dh, tol=numpy.finfo(float).eps):
     """
     return list(map(lambda x: compute_vertex(x, dh, tol=tol), origin_points))
 
-def _bin_catalog_spatio_magnitude_counts(lons, lats, mags, n_poly, mask, idx_map, binx, biny, mag_bins, tol=0.00001):
+def _bin_catalog_spatio_magnitude_counts(lons, lats, mags, n_poly, mask, idx_map, binx, biny, mag_bins, tol=None):
     """
     Returns a list of event counts as ndarray with shape (n_poly, n_cat) where each value
     represents the event counts within the polygon.
@@ -1182,7 +1182,7 @@ class QuadtreeGrid2D:
         out = numpy.zeros([len(self.quadkeys), len(mag_bins)])
 
         idx_loc = self.get_index_of(lon, lat)
-        idx_mag = bin1d_vec(mag, mag_bins, tol=0.00001, right_continuous=True)
+        idx_mag = bin1d_vec(mag, mag_bins, right_continuous=True)
 
         numpy.add.at(out, (idx_loc, idx_mag), 1)
 

--- a/csep/utils/calc.py
+++ b/csep/utils/calc.py
@@ -70,7 +70,7 @@ def bin1d_vec(p, bins, tol=None, right_continuous=False):
 
     Args:
         p (array-like): Point(s) to be placed into b
-        bins (array-like): bins to considering for binning, must be monotonically increasing
+        bins (array-like): bin edges; must be sorted (monotonically increasing)
         right_continuous (bool): if true, consider last bin extending to infinity
 
     Returns:
@@ -82,7 +82,9 @@ def bin1d_vec(p, bins, tol=None, right_continuous=False):
     bins = numpy.array(bins)
     p = numpy.array(p)
 
-    a0 = numpy.min(bins)
+    # if not np.all(bins[:-1] <= bins[1:]):  # check for sorted bins, which is a requirement
+    #     raise ValueError("Bin edges are not sorted.")  # (pyCSEP always passes sorted bins)
+    a0 = bins[0]
     if bins.size == 1:
         # for a single bin, set `right_continuous` to true; h is now arbitrary
         right_continuous = True

--- a/csep/utils/calc.py
+++ b/csep/utils/calc.py
@@ -98,7 +98,7 @@ def bin1d_vec(p, bins, tol=None, right_continuous=False):
     if bins.size == 1:
         # for a single bin, set `right_continuous` to true; h is now arbitrary
         right_continuous = True
-        h = bins[0]  # (just take over dtype)
+        h = 1.
     else:
         h = bins[1] - bins[0]
 

--- a/csep/utils/calc.py
+++ b/csep/utils/calc.py
@@ -79,8 +79,8 @@ def bin1d_vec(p, bins, tol=None, right_continuous=False):
     Raises:
         ValueError:
     """
-    bins = numpy.array(bins)
-    p = numpy.array(p)
+    bins = numpy.asarray(bins)
+    p = numpy.asarray(p)
 
     # if not np.all(bins[:-1] <= bins[1:]):  # check for sorted bins, which is a requirement
     #     raise ValueError("Bin edges are not sorted.")  # (pyCSEP always passes sorted bins)

--- a/csep/utils/calc.py
+++ b/csep/utils/calc.py
@@ -213,12 +213,13 @@ def cleaner_range(start, end, h):
     Returns:
         bin_edges (numpy.ndarray)
     """
-    # convert to integers to prevent accumulating floating point errors
-    const = 100000
-    start = numpy.floor(const * start)
-    end = numpy.floor(const * end)
-    d = const * h
-    return numpy.arange(start, end + d / 2, d) / const
+    # determine required scaling to account for decimal places of bin edges and stepping
+    num_decimals_bins = len(str(float(start)).split('.')[1])
+    scale = max(10**num_decimals_bins, 1 / h)
+    start = numpy.round(scale * start)
+    end = numpy.round(scale * end)
+    d = scale * h
+    return numpy.arange(start, end + d / 2, d) / scale
 
 def first_nonnan(arr, axis=0, invalid_val=-1):
     mask = arr==arr

--- a/csep/utils/calc.py
+++ b/csep/utils/calc.py
@@ -80,7 +80,7 @@ def bin1d_vec(p, bins, tol=None, right_continuous=False):
         h = bins[1] - bins[0]
 
     a0_tol = numpy.abs(a0) * numpy.finfo(numpy.float64).eps
-    h_tol = numpy.abs(h) * numpy.finfo(numpy.float64).eps
+    h_tol = a0_tol  # must be based on *involved* numbers
     p_tol = numpy.abs(p) * numpy.finfo(numpy.float64).eps
 
     # absolute tolerance

--- a/csep/utils/calc.py
+++ b/csep/utils/calc.py
@@ -101,27 +101,15 @@ def bin1d_vec(p, bins, tol=None, right_continuous=False):
     p_tol = tol or _get_tolerance(p)
 
     idx = numpy.floor((p - a0 + p_tol + a0_tol) / (h - h_tol))
+    idx = numpy.asarray(idx)  # assure idx is an array
 
     if right_continuous:
         # set upper bin index to last
-        try:
-            idx[(idx < 0)] = -1
-            idx[(idx >= len(bins) - 1)] = len(bins) - 1
-        except TypeError:
-            if idx >= len(bins) - 1:
-                idx = len(bins) - 1
-            if idx < 0:
-                idx = -1
+        idx[idx < 0] = -1
+        idx[idx >= len(bins) - 1] = len(bins) - 1
     else:
-        try:
-            idx[((idx < 0) | (idx >= len(bins)))] = -1
-        except TypeError:
-            if idx < 0 or idx >= len(bins):
-                idx = -1
-    try:
-        idx = idx.astype(numpy.int64)
-    except AttributeError:
-        idx = int(idx)
+        idx[(idx < 0) | (idx >= len(bins))] = -1
+    idx = idx.astype(numpy.int64)
     return idx
 
 def _compute_likelihood(gridded_data, apprx_rate_density, expected_cond_count, n_obs):

--- a/csep/utils/calc.py
+++ b/csep/utils/calc.py
@@ -52,7 +52,9 @@ def discretize(data, bin_edges, right_continuous=False):
     return x_new
 
 def _get_tolerance(v):
-    """Determine a numerical tolerance due to limited precision of floating-point values.
+    """Determine numerical tolerance due to limited precision of floating-point values.
+
+    ... to account for roundoff error.
 
     In other words, returns a maximum possible difference that can be considered negligible.
     Only relevant for floating-point values.
@@ -64,17 +66,25 @@ def _get_tolerance(v):
 def bin1d_vec(p, bins, tol=None, right_continuous=False):
     """Efficient implementation of binning routine on 1D Cartesian Grid.
 
-    Returns the indices of the points into bins. Bins are inclusive on the lower bound
+    Bins are inclusive on the lower bound
     and exclusive on the upper bound. In the case where a point does not fall within the bins a -1
     will be returned. The last bin extends to infinity when right_continuous is set as true.
 
+    To correctly bin points that are practically on a bin edge, this function accounts for the
+    limited precision of floating-point numbers (the roundoff error) with a numerical tolerance.
+    If the provided points were subject to some floating-point operations after loading or
+    generating them, the roundoff error increases (which is not accounted for) and requires
+    overwriting the `tol` argument.
+
     Args:
-        p (array-like): Point(s) to be placed into b
+        p (array-like): Point(s) to be placed into bins.
         bins (array-like): bin edges; must be sorted (monotonically increasing)
-        right_continuous (bool): if true, consider last bin extending to infinity
+        tol (float): overwrite numerical tolerance, by default determined automatically from the
+                     points' dtype to account for the roundoff error.
+        right_continuous (bool): if true, consider last bin extending to infinity.
 
     Returns:
-        idx (array-like): indexes hashed into grid
+        numpy.ndarray: indices for the points corresponding to the bins.
 
     Raises:
         ValueError:

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -106,6 +106,13 @@ class TestBin1d(unittest.TestCase):
         expected = [-1, -1, 0, 0, 0, 0, 0, -1]
         self.assertListEqual(test.tolist(), expected)
 
+    def test_bin1d_single_bin2(self):
+        data = [4.0]
+        bin_edges = [3.0]
+        test = bin1d_vec(data, bin_edges)
+        expected = [0]
+        self.assertListEqual(test.tolist(), expected)
+
     def test_upper_limit_right_continuous(self):
         data = [40, 40, 40]
         bin_edges = [0, 10, 20, 30]
@@ -134,18 +141,27 @@ class TestBin1d(unittest.TestCase):
         expected = [-1, 3, -1]
         self.assertListEqual(test.tolist(), expected)
 
-    def test_scalar_outside(self):
-        from csep.utils.calc import bin1d_vec
-        mbins = numpy.arange(5.95, 9, 0.1)  # This gives bins from 5.95 to 8.95
-        idx = bin1d_vec(5.95, mbins, right_continuous=True)
-        self.assertEqual(idx, 0)
+    def test_scalar_inside(self):
+        mbins = numpy.arange(5.95, 9, 0.1)  # (magnitude) bins from 5.95 to 8.95
 
-        idx = bin1d_vec(6, mbins, right_continuous=True)  # This would give 0: Which is fine.
-        self.assertEqual(idx, 0)
+        for i, m in enumerate(mbins):
+            idx = bin1d_vec(m, mbins, right_continuous=True)  # corner cases
+            self.assertEqual(idx, i)
+
+            idx = bin1d_vec(m + 0.05, mbins, right_continuous=True)  # center bins
+            self.assertEqual(idx, i)
+
+            idx = bin1d_vec(m + 0.099999999, mbins, right_continuous=True)  # end of bins
+            self.assertEqual(idx, i)
+
+        idx = bin1d_vec(10, mbins, right_continuous=True)  # larger than last bin edge
+        self.assertEqual(idx, mbins.size - 1)
+
+    def test_scalar_outside(self):
+        mbins = numpy.arange(5.95, 9, 0.1)  # (magnitude) bins from 5.95 to 8.95
 
         idx = bin1d_vec(5, mbins, right_continuous=True)
         self.assertEqual(idx, -1)
 
         idx = bin1d_vec(4, mbins, right_continuous=True)
         self.assertEqual(idx, -1)
-

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -137,15 +137,15 @@ class TestBin1d(unittest.TestCase):
     def test_scalar_outside(self):
         from csep.utils.calc import bin1d_vec
         mbins = numpy.arange(5.95, 9, 0.1)  # This gives bins from 5.95 to 8.95
-        idx = bin1d_vec(5.95, mbins, tol=0.00001, right_continuous=True)
+        idx = bin1d_vec(5.95, mbins, right_continuous=True)
         self.assertEqual(idx, 0)
 
-        idx = bin1d_vec(6, mbins, tol=0.00001, right_continuous=True)  # This would give 0: Which is fine.
+        idx = bin1d_vec(6, mbins, right_continuous=True)  # This would give 0: Which is fine.
         self.assertEqual(idx, 0)
 
-        idx = bin1d_vec(5, mbins, tol=0.00001, right_continuous=True)
+        idx = bin1d_vec(5, mbins, right_continuous=True)
         self.assertEqual(idx, -1)
 
-        idx = bin1d_vec(4, mbins, tol=0.00001, right_continuous=True)
+        idx = bin1d_vec(4, mbins, right_continuous=True)
         self.assertEqual(idx, -1)
 

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -3,7 +3,11 @@ import unittest
 
 import numpy
 
-from csep.core.regions import italy_csep_region, california_relm_region, nz_csep_region
+from csep.core.regions import (
+    italy_csep_region, italy_csep_collection_region,
+    california_relm_region, california_relm_collection_region,
+    nz_csep_region, nz_csep_collection_region,
+)
 
 def get_italy_region_fname():
     root_dir = os.path.dirname(os.path.abspath(__file__))
@@ -96,8 +100,12 @@ class TestBin2d(unittest.TestCase):
         # (loading those is the bottleneck of this test case)
         cls.regions = [
             italy_csep_region(),
+            italy_csep_collection_region(),
             california_relm_region(),
-            nz_csep_region()
+            california_relm_collection_region(),
+            nz_csep_region(),
+            nz_csep_collection_region(),
+            # global_region()  # extreme slow-down (~2min loading + ~5min per loop + ~4s per vect)
         ]
 
     def test_bin2d_regions_origins(self):

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -86,3 +86,72 @@ class TestNZRegion(unittest.TestCase):
         r = nz_csep_region()
         # they dont have to be in the same order, but they need
         numpy.testing.assert_array_equal(r.midpoints().sort(), self.from_dat.sort())
+
+class TestBin2d(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestBin2d, cls).setUpClass()
+
+        # (loading those is the bottleneck of this test case)
+        cls.regions = [
+            italy_csep_region(),
+            california_relm_region(),
+            nz_csep_region()
+        ]
+
+    def test_bin2d_regions_origins(self):
+        """every origin must be inside its own bin
+        """
+
+        for region in self.regions:
+            origins = region.origins()
+            self._test_bin2d_region_loop(region, origins)
+            self._test_bin2d_region_vect(region, origins)
+            self._test_bin2d_region_vect(region, origins.astype(numpy.float32))
+
+    def test_bin2d_regions_midpoints(self):
+        """every midpoint must be inside its own bin
+        """
+
+        for region in self.regions:
+            midpoints = region.midpoints()
+            self._test_bin2d_region_loop(region, midpoints)
+            self._test_bin2d_region_vect(region, midpoints)
+            self._test_bin2d_region_vect(region, midpoints.astype(numpy.float32))
+
+    def test_bin2d_regions_endcorner(self):
+        """every corner point (~opposite end of the origin) must be inside its own bin
+        """
+
+        for region in self.regions:
+            frac = 0.9999999999
+            endcorners = region.origins() + frac*region.dh
+            self._test_bin2d_region_loop(region, endcorners)
+            self._test_bin2d_region_vect(region, endcorners)
+            frac = 0.999  # decrease frac for float32 due to its lower resolution
+            endcorners = region.origins() + frac*region.dh
+            self._test_bin2d_region_vect(region, endcorners.astype(numpy.float32))
+
+    def _test_bin2d_region_loop(self, region, coords):
+        """(slow) loop over origins; each time, calls bin1d_vec for lat & lon scalars
+        """
+
+        for i, origin in enumerate(coords):
+            idx = region.get_index_of(
+                origin[0],
+                origin[1],
+            )
+            self.assertEqual(i, idx)
+
+    def _test_bin2d_region_vect(self, region, coords):
+        """call bin1d_vec once for all lat origins & all lon origins
+
+        Besides, also tests if vectors with ndim=2 are consumed properly
+        (returns 2nd-order/nested list ([[...]]).
+        """
+
+        lons, lats = numpy.split(coords.T, 2)  # both have ndim=2!
+        test = region.get_index_of(lons, lats).tolist()  # nested list ([[...]])
+        expected = [numpy.arange(len(region.origins())).tolist()]  # embed in another list
+        self.assertListEqual(test, expected)


### PR DESCRIPTION
⚠ Caution, longer treatise ahead! 🤷‍♂️

### 1. Solving numerical issues (#255)

I [previously proposed a preliminary fix](https://github.com/SCECcode/pycsep/issues/255#issuecomment-2548687127) based on rounding the estimated bin size `h`. But there's a more elegant [fix](https://github.com/SCECcode/pycsep/commit/e12f6a0):

```diff
-    h_tol = numpy.abs(h) * numpy.finfo(numpy.float64).eps
+    h_tol = a0_tol
```
in [this line](https://github.com/SCECcode/pycsep/blob/2feb9148/csep/utils/calc.py#L83).

This change is sufficient because the prior floating-point operation `h = bins[1] - bins[0]` in the [previous line](https://github.com/SCECcode/pycsep/blob/2feb9148/csep/utils/calc.py#L83) carries the unit [roundoff error](https://en.wikipedia.org/wiki/Round-off_error) of the involved numbers (and may introduce a further roundoff error). To account for it, the tolerance must be based on machine `eps`ilon and the _involved_ numbers (not the resulting number). In our case, the two involved numbers in calculating `h` are of the same order of magnitude, and one of it is `a0` (i.e., the first bin edge `bin[0] == min(bins)`), for which we already calculate the tolerance (`a0_tol`). So we can use `a0_tol` also as tolerance for `h`.

Here's an illustration:

```
       bin1:   31.50000000000000000 (a0)
       bin2:   31.60000000000000142

          h:    0.10000000000000142 (bin2 - a0)
imprecision:    0.00000000000000142 (|h - 0.1|)

        eps:    0.00000000000000022 (FYI)
    |h|*eps:    0.00000000000000002 (previous h_tol)

   |a0|*eps:    0.00000000000000699 (new h_tol)
```

To account for the floating-point/roundoff errors, `h_tol` must be larger than the `imprecision` of `h`.
Only the new `h_tol` estimation guarantees that by reusing `a0_tol = abs(a0) * eps`.

> FYI: accounting for `h_tol` would not be necessary if the actual bin size `h` is accurately specified (e.g., `0.1`), i.e., not based on a prior operation. `CartesianGrid` already stores it as meta-data `.dh`, which is _exactly_ `0.1` for all currently implemented regions. `bin1d_vec` _could_ be adapted to receive this bin size as an additional argument. But `bin1d_vec` is also [used for binning magnitudes](https://github.com/search?q=repo%3ASCECcode%2Fpycsep+bin1d_vec%28&type=code), for which the bin size is not explicitly stored in the `region`. Of course we could change that and pass it to `bin1d_vec`, but I believe it's not necessary (for now).


### 2. Further enhancements

#### 2.1 to `bin1d_vec`

Working with and looking at `bin1d_vec` way too often, I noticed that it can be simplified, made more robust/versatile _and_ (slightly) speed up by addressing various aspects. In the following, I list each incremental enhancement and measure its performance; I committed them separately for convenience and providing related notes in their description.

To quantify the performance speed-up, I timed the self-check over all origins for California, but – to avoid the overhead in `get_index_of` – only for one coordinate component by directly calling `bin1d_vec` in two ways:
1. looped (7682 individual call): `%timeit -r 300 -n 1 for origin in region.origins(): bin1d_vec(origin[0], region.xs)`
2. vectorized (vector with 7682 values), which matters much more in practice: `%timeit -r 6000 -n 100 bin1d_vec(origins_lon, region.xs)`

| Enhancement                                             | **vectorized** |  looped |
|:--------------------------------------------------------|---------------:|--------:|
| [Only the bare fix](https://github.com/SCECcode/pycsep/commit/e12f6a0)                                       |    **23.8 µs** | 36.3 ms |
| [1. Reorganize + make tolerance depend on _dtype_](https://github.com/SCECcode/pycsep/commit/79c08dd)        |    **24.1 µs** | 37.7 ms |
| [2. Replace `.min(bins)` with `bins[0]`](https://github.com/SCECcode/pycsep/commit/ec74058)                  |    **22.2 µs** | 26.3 ms |
| [3. Use `.asarray()` instead of `.array()`](https://github.com/SCECcode/pycsep/commit/22aac12)               |    **20.7 µs** | 24.8 ms |
| [4. Avoid try/except by always operating on arrays](https://github.com/SCECcode/pycsep/commit/1fac3b)       |    **20.8 µs** | 31.4 ms |

<br>

> Notes about `bin1d_vec` (for those interested):
> * As mentioned in `bin1d_vec`'s docstring, ["`bins [...] must be monotonically increasing`"](https://github.com/SCECcode/pycsep/blob/2feb9148/csep/utils/calc.py#L63) because the implemented `idx` calculation assumes/requires sorted bins (for this reason, there is no need for `.min()`). This is not checked, presumably because _pyCSEP_ itself never passes unsorted bins to this method (they always originate from ranges). Nevertheless, I added a check at the top, but commented it out; we may activate it in the future if there is need - for now, it only serves as an additional hint.
> * for passing the unit tests mentioned below, the necessary tolerances to add in the `idx` calculation depend on the _dtype_ of `p`:
>     * _float64_ doesn't need adding `a0_tol` nor `p_tol`;
>     * _float32_ doesn't need adding `a0_tol`, but `p_tol` (since `p` is _float32_);
>     * --> So `a0_tol` could be omitted, but to avoid unforeseeable future oddities, let's keep it anyway (and because it theoretically makes sense adding it).
> * the grouping and order of terms in the `idx` calculation influence the roundoff error, see [_What Every Computer Scientist Should Know About Floating-Point Arithmetic_](https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html). Illustration:
> ```
>  40.40000000000000568 (p)
>  31.50000000000000000 (a0)
>   0.00000000000003728 (p_tol)
>   0.00000000000003679 (a0_tol)
>
>   8.90000000000000568 (p - a0)
>   0.00000000000007407 (p_tol + a0_tol)
>
>   8.90000000000007674  <--  p + (p_tol + a0_tol) - a0  [ORIGINAL]
>   8.90000000000007674  <--  p + p_tol + a0_tol - a0
>   8.90000000000008029  <--  p - a0 + (p_tol + a0_tol)
>   8.90000000000008029  <--  p - a0 + p_tol + a0_tol    [NEW]
>   8.90000000000007851  <--  p + p_tol - a0 + a0_tol
> ```
> > Only the 3rd and 4th option is closest to (and occasionally exactly) the actual sum (and is largest). In the first enhancement step, I used the 4th option. 

#### 2.2 other changes

* in `region.CartesianGrid2D.get_index_of()`, I also [removed `numpy.array()`](https://github.com/SCECcode/pycsep/commit/9c14ee8) (redundant with first lines in `bin1d_vec`; should slightly speed up spatial binning)
* [drop any `tol=0.00001` from `bin1d_vec` calls or functions that call it](https://github.com/SCECcode/pycsep/commit/0b95738) (only used when binning magnitudes), even in the unit tests

<br>

> Notes (for those interested):
> * specifying `tol=0.00001` was not even necessary with the revised tolerance section by [commit 949d342c](https://github.com/SCECcode/pycsep/commit/949d342c) (albeit most of the `tol=0.00001` were introduced by this commit);
>    * Why? because magnitude bins are "cleanly" created with `np.arange()` in [`csep.core.regions.magnitude_bins`](https://docs.cseptesting.org/_modules/csep/core/regions.html#magnitude_bins);
>    * their redundancy is confirmed by passing the extended unit test `test_scalar_inside` (see below) without `tol=0.00001` using the unfixed `bin1d_vec`;
>    * yet, I left the optional `tol=None` argument in `bin1d_vec` and the functions that call it – just in case there is a real need to override the tolerance.


### 3. [Extend unit tests](https://github.com/SCECcode/pycsep/commit/92e33f0470da28edea8371e4687c954d5d8278b1)

* in `test_calc.TestBin1d`:
    * add `test_bin1d_single_bin2`, which inputs a single bin _and_ a single point;
    * split off a new `test_scalar_inside` from `test_scalar_outside`, which checks for (magnitude) bin edges `5.95, 6.05, ..., 8.95`:
        * _all_ corner cases (*.*5)
        * _all_ center bins (*.*0)
        * _all_ end of bins (*.*99999999)
        * one large value (10)
* add separate class `TestBin2d` in `test_region`, which makes more realistic unit tests by extending the self-check mentioned in #255 and performing it...
    * for three regions: Italy, California, NZ (New-Zealand);
    * for all origins, mid-points, and end-corners (in the bin at the opposite side of origin);
    * for double precision (_float64_ / _f8_) and single precision (_float32_ / _f4_) of the _points_ (not bins);
    * as loop (over each point individually) and single vector (all points at once).
    * ==> 36 unit test combinations
    * (albeit targeting `bin1d_vec`, it also unit-tests region's [`CartesianGrid2D.get_index_of`](https://github.com/SCECcode/pycsep/blob/2feb9148/csep/core/regions.py#L618) and by extension [`GriddedForecast.get_index_of`](https://docs.cseptesting.org/reference/generated/csep.core.forecasts.GriddedForecast.get_index_of.html))

<br>

> Notes (for those interested):
> * the _float32_-based unit tests only pass after the first enhancement in the previous section;
>     * (_float32_ is not a use case when using pyCSEP's implemented [readers](https://github.com/SCECcode/pycsep/blob/main/csep/utils/readers.py) [normally](https://docs.cseptesting.org/concepts/catalogs.html#id7) (read values will eventually be converted to `float64` [here](https://github.com/SCECcode/pycsep/blob/2feb9148/csep/core/catalogs.py#L284) by using [these specified dtypes](https://github.com/SCECcode/pycsep/blob/2feb9148/csep/core/catalogs.py#L883)), but it could happen with a custom loader function and the intention to save some memory - note that the [reader module](https://github.com/SCECcode/pycsep/blob/main/csep/utils/readers.py) still reveals some (incorrect) mentions of `float32`/`f4` in the docstrings). 
> * the unit tests for the NZ region only pass after addressing another issue in the next section.


### 4. Another issue: imprecise bin edge creation

For the NZ region, the end-corner-based unit test (`test_bin2d_regions_endcorner`) failed; inspecting the problematic corner point for the Longitude yields:

```
      origin: 167.79999999999998
           p: 167.89998999999997
          a0: 165.69999
           h: 0.09999999999999432
      p - a0: 2.19999999999996
```
It took me a while to spot the culprit; but this helped:
```
region.xs: [165.69999, 165.79999, 165.89999, 165.99999, 166.09999, 166.19999, 166.29999, 166.39999, ...]
dh: 0.1
```

Oops, they are not rounded to the first decimal digit despite `region.dh == 0.1`!

> FYI: The chain leading to failed test:
>  1. improperly rounded `.xs` (`.*9999`)
>  2. ... causes a likewise imprecise `a0`
>  3. ... which causes `(p - a0 + p_tol + a0_tol) / (h - h_tol)` to be just above `22` (`22.000099999901586`), instead of being just below (`21.99999999990184`)
>  4. ... which eventually nudges `idx` into the next bin

Apparently, the underlying [`csep.utils.calc.cleaner_range()`](https://github.com/SCECcode/pycsep/blob/2feb9148/csep/utils/calc.py#L204) is the culprit. It turns out that the particularly chosen `const = 100000` leads to weird numerical imprecision (it doesn't happen if it were 10'000 or 1'000'000):
```
165.7 * 100000  = 16569999.999999998 <-- the chosen `const`
165.7 * 10000   = 1657000.0
165.7 * 1000000 = 165700000.0
```
Then `np.floor(const * start)` operation yields `16569999.0` instead of `1657000.0`.

[Numpy's user guide](https://numpy.org/doc/stable/user/how-to-partition.html) suggest:
> _Use `numpy.linspace` if you want the endpoint to be included in the result, or if you are using a **non-integer step size**._

I tried it, but some bin edges still contained `.*99999...`.

Instead, I [modified `cleaner_range()` only in some other aspects](https://github.com/SCECcode/pycsep/commit/a836927). The crucial modification is using `round` instead of `floor` – very related to the [problematics that lead me to this PR](https://github.com/SCECcode/pycsep/issues/255#issuecomment-2548687127). The other change – replacing the hard-coded `const` with a flexible `scale` parameter – is supposed to account for the number of decimal digits of bin edges _and_ stepping (`const = 100000` would lead to imprecise bin edges if `h < 0.000'01` or if the bin edges start at `*.000'001` – maybe someone needs that in the future 😉).

> Note (for those interested):
> This sub-issue is apparently caused by using `numpy.loadtxt()` inside `nz_csep_region()` instead of [`parse_csep_template()`](https://github.com/SCECcode/pycsep/blob/2feb9148/csep/core/regions.py#L334) as used for reading the California and Italy CSEP region, which uses `float()` from the Python standard library. So this additional fix makes bin creation more robust to input produced with different reader functions.

In the [same commit](https://github.com/SCECcode/pycsep/commit/a836927), I also simplified `core.regions.magnitude_bins()` to just call (this improved) `cleaner_range()`; it was essentially a copy of it.


### 5. Implication on existing test results

As mentioned in my [original comment of issue #255](https://github.com/SCECcode/pycsep/issues/255), test results produced after this PR will become irreproducible with past results **_only if_** the test catalog contains one or more events whose coordinates align with the region's spatial bin edges, e.g., a coarse single-decimal-digit coordinate like 42.3° and a gridding of 0.1°. Otherwise, this issue and PR is irrelevant.

But even if a catalog _does_ contain such events, I don't expect test results would change significantly – perhaps only if _all_ events have coarse locations. Be reminded that I spotted this whole issue only due to a difference at the 3-5th decimal digit for IGPE compared to an independent binning implementation; the test catalog contained five of such events (262 events in total).

I still wanted to assess if this PR leads to some irreproducibility, so I ran our [first reproducibility package](https://github.com/wsavran/pycsep_esrl_reproducibility) using the most recent pyCSEP state (v0.6.3 + 22 commits) – once without and once with all changes in this PR. Eventually, they were exactly the same (up to the last [15th] decimal digit).[^1] Apparently, it doesn't involve events with coarse locations (this is a good thing!).

Apart that, I didn't do other comparisons; feel free to suggest me some (they should contain events with coarse locations and/or involve the NZ region).

---

Closes #255


[^1]: Btw: they were not exactly the same as the [expected output](https://github.com/wsavran/pycsep_esrl_reproducibility/tree/main/expected_output/results) due to some occasional mismatches at the last (15th) decimal digit. These slight mismatches are likely due to using a different platform/OS and/or a different combination of packages (I installed the most up-to-date versions of packages specified in pyCSEP's `requirements.yml` + adjusted `numpy==1.22.4` and `matplotlib==3.5.2` to get a compatible environment for the newest pyCSEP version).