### PR TITLE
Update build-test.yml

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         include:
           - os: windows-latest
             python-version: '3.10'
@@ -38,7 +38,7 @@ jobs:
 
       - name: Test with pytest
         run: |
-          pip install vcrpy==4.3.1 pytest pytest-cov
+          pip install vcrpy pytest pytest-cov
           pytest --cov=./ --cov-config=.coveragerc
 
       - name: Upload coverage
@@ -72,5 +72,5 @@ jobs:
 
       - name: Test with pytest
         run: |
-          pip install vcrpy==4.3.1 pytest pytest-cov
+          pip install vcrpy pytest pytest-cov
           pytest --cov=./ --cov-config=.coveragerc


### PR DESCRIPTION
- removed pinned vcrpy version
- added python 3.12 and removed 3.8 to match our documentation

needed for #270 

@fabiolsilva, @pabloitu we will know if it works from the actions running, if they all pass we should be good to have @mherrmann3 rebase his commit onto main and it should fix the problem.