### PR TITLE
Removed scipy.repeats due to function deprecation

### DIFF
--- a/csep/core/poisson_evaluations.py
+++ b/csep/core/poisson_evaluations.py
@@ -555,7 +555,9 @@ def _w_test_ndarray(x, m=0):
     mn = count * (count + 1.) * 0.25
     se = count * (count + 1.) * (2. * count + 1.)
 
-    replist, repnum = scipy.stats.find_repeats(r)
+    _, repnum = numpy.unique(r, return_counts=True)
+    repnum = repnum[repnum > 1]
+
     if repnum.size != 0:
         # Correction for repeated elements.
         se -= 0.5 * (repnum * (repnum * repnum - 1)).sum()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pycsep"
-dynamic = ["version"]              # <— version comes from SCM
+dynamic = ["version"]
 description = "Python tools from the Collaboratory for the Study of Earthquake Predictability"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_csep1_evaluations.py
+++ b/tests/test_csep1_evaluations.py
@@ -109,6 +109,25 @@ class TestGriddedForecastTests(unittest.TestCase):
         print('W Test: Running Unit Test')
         self.assertEqual(_w_test_ndarray(x, median), expected_output, 'Failed W Test')
 
+        out_rev = _w_test_ndarray(x[::-1], median)
+        self.assertAlmostEqual(out_rev['z_statistic'], expected_output['z_statistic'], places=15)
+        self.assertAlmostEqual(out_rev['probability'], expected_output['probability'], places=15)
+
+        x_with_zeros = numpy.concatenate([x, numpy.array([median, median, median])])
+        out_with_zeros = _w_test_ndarray(x_with_zeros, median)
+        self.assertAlmostEqual(out_with_zeros['z_statistic'], expected_output['z_statistic'], places=15)
+        self.assertAlmostEqual(out_with_zeros['probability'], expected_output['probability'], places=15)
+
+        x_ties = numpy.array([median + 1, median - 1,
+                              median + 2, median - 2,
+                              median + 2, median - 2,
+                              median + 5, median - 5,
+                              median + 10, median - 10], dtype=float)
+        out_ties = _w_test_ndarray(x_ties, median)
+        self.assertTrue(numpy.isfinite(out_ties['z_statistic']))
+        self.assertTrue(0.0 <= out_ties['probability'] <= 1.0)
+
+
     def test_t_test(self):
         pass
         """


### PR DESCRIPTION
fix: removed scipy.find_repeats in w_test due to scipy deprecated function. Replaced with numpy.unique

build: removed comment from .toml

# pyCSEP Pull Request Checklist

Please check out the [contributing guidelines](https://github.com/SCECcode/pycsep/blob/master/CONTRIBUTING.md) for some tips 
on making pull requests to pyCSEP. 

Fixes issue #(*please fill in or delete if not needed*).

## Type of change:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (this pull request adds no new code)
- [x] Unpublished science feature (This may require a science review)
- [x] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
